### PR TITLE
Replace "return" with "pure"

### DIFF
--- a/Yaml.idr
+++ b/Yaml.idr
@@ -98,11 +98,11 @@ yamlNumber : Parser Double
 yamlNumber = map scientificToDouble parseScientific
 
 yamlBool : Parser Bool
-yamlBool  =  (char 't' >! string "rue"  *> return True)
-         <|> (char 'f' >! string "alse" *> return False) <?> "Yaml Bool"
+yamlBool  =  (char 't' >! string "rue"  *> pure True)
+         <|> (char 'f' >! string "alse" *> pure False) <?> "Yaml Bool"
 
 yamlNull : Parser ()
-yamlNull = (char 'n' >! string "ull" >! return ()) <?> "Yaml Null"
+yamlNull = (char 'n' >! string "ull" >! pure ()) <?> "Yaml Null"
 
 ||| A parser that skips whitespace without jumping over lines
 yamlSpace : Monad m => ParserT String m ()


### PR DESCRIPTION
Idris 1.2 considers "return" to be "fragile":
`return` is provided for those coming from Haskell. Please use `pure` instead, which is equivalent.